### PR TITLE
[CancelOperation] config run on background

### DIFF
--- a/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
+++ b/packages/amplify_api/android/src/main/kotlin/com/amazonaws/amplify/amplify_api/AmplifyApiPlugin.kt
@@ -16,6 +16,7 @@
 package com.amazonaws.amplify.amplify_api
 
 import android.content.Context
+import android.os.AsyncTask
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
@@ -132,8 +133,12 @@ class AmplifyApiPlugin : FlutterPlugin, MethodCallHandler {
         cancelToken: String
     ) {
         if (OperationsManager.containsOperation(cancelToken)) {
-            OperationsManager.cancelOperation(cancelToken)
-            flutterResult.success("Operation Canceled")
+            AsyncTask.execute {
+                OperationsManager.cancelOperation(cancelToken)
+                handler.post {
+                    flutterResult.success("Operation Canceled")
+                }
+            }
         } else {
             flutterResult.error(
                 "AmplifyAPI-CancelError",


### PR DESCRIPTION
- Issue: Cancel Operation is running on main thread, which freeze UI about 200ms
- Solution: Using AsyncTask to run task on background, and handler to invoke callback in main thread